### PR TITLE
Add support for custom OpenAI base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ claude mcp add o3 -s user \
 	-e OPENAI_API_KEY=your-api-key \
 	-e SEARCH_CONTEXT_SIZE=medium \
 	-e REASONING_EFFORT=medium \
+	-e OPENAI_BASE_URL=https://your-custom-endpoint.com/v1 \
 	-- npx o3-search-mcp
 ```
 
@@ -32,7 +33,9 @@ json:
         "OPENAI_API_KEY": "your-api-key",
         // Optional: low, medium, high (default: medium)
         "SEARCH_CONTEXT_SIZE": "medium",
-        "REASONING_EFFORT": "medium"
+        "REASONING_EFFORT": "medium",
+        // Optional: custom OpenAI API base URL for enterprise servers
+        "OPENAI_BASE_URL": "https://your-custom-endpoint.com/v1"
       }
     }
   }
@@ -58,6 +61,7 @@ $ claude mcp add o3 -s user \
 	-e OPENAI_API_KEY=your-api-key \
 	-e SEARCH_CONTEXT_SIZE=medium \
 	-e REASONING_EFFORT=medium \
+	-e OPENAI_BASE_URL=https://your-custom-endpoint.com/v1 \
 	-- node /path/to/o3-search-mcp/build/index.js
 ```
 
@@ -73,7 +77,9 @@ json:
         "OPENAI_API_KEY": "your-api-key",
         // Optional: low, medium, high (default: medium)
         "SEARCH_CONTEXT_SIZE": "medium",
-        "REASONING_EFFORT": "medium"
+        "REASONING_EFFORT": "medium",
+        // Optional: custom OpenAI API base URL for enterprise servers
+        "OPENAI_BASE_URL": "https://your-custom-endpoint.com/v1"
       }
     }
   }

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ const server = new McpServer({
 // Initialize OpenAI client
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
+  baseURL: process.env.OPENAI_BASE_URL,
 });
 
 // Configuration from environment variables

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ const server = new McpServer({
 // Initialize OpenAI client
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
-  baseURL: process.env.OPENAI_BASE_URL,
+  ...(process.env.OPENAI_BASE_URL && { baseURL: process.env.OPENAI_BASE_URL }),
 });
 
 // Configuration from environment variables


### PR DESCRIPTION
This PR enables the use of enterprise-hosted OpenAI API deployments. It introduces a configuration option for specifying a custom base URL, allowing the application to connect to OpenAI instances outside of the standard public endpoint.