### PR TITLE
feat: Add configurable retry and timeout for OpenAI API.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 OPENAI_API_KEY=your_openai_api_key_here
 SEARCH_CONTEXT_SIZE=medium  # Options: low, medium, high
 REASONING_EFFORT=medium     # Options: low, medium, high
+OPENAI_API_TIMEOUT=60000    # API timeout in milliseconds (default: 60000)
+OPENAI_MAX_RETRIES=3        # Maximum retry attempts (default: 3)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ $ claude mcp add o3 -s user \
 	-e OPENAI_API_KEY=your-api-key \
 	-e SEARCH_CONTEXT_SIZE=medium \
 	-e REASONING_EFFORT=medium \
+	-e OPENAI_API_TIMEOUT=60000 \
+	-e OPENAI_MAX_RETRIES=3 \
 	-- npx o3-search-mcp
 ```
 
@@ -32,7 +34,11 @@ json:
         "OPENAI_API_KEY": "your-api-key",
         // Optional: low, medium, high (default: medium)
         "SEARCH_CONTEXT_SIZE": "medium",
-        "REASONING_EFFORT": "medium"
+        "REASONING_EFFORT": "medium",
+        // Optional: API timeout in milliseconds (default: 60000)
+        "OPENAI_API_TIMEOUT": "60000",
+        // Optional: Maximum retry attempts (default: 3)
+        "OPENAI_MAX_RETRIES": "3"
       }
     }
   }
@@ -58,6 +64,8 @@ $ claude mcp add o3 -s user \
 	-e OPENAI_API_KEY=your-api-key \
 	-e SEARCH_CONTEXT_SIZE=medium \
 	-e REASONING_EFFORT=medium \
+	-e OPENAI_API_TIMEOUT=60000 \
+	-e OPENAI_MAX_RETRIES=3 \
 	-- node /path/to/o3-search-mcp/build/index.js
 ```
 
@@ -73,9 +81,31 @@ json:
         "OPENAI_API_KEY": "your-api-key",
         // Optional: low, medium, high (default: medium)
         "SEARCH_CONTEXT_SIZE": "medium",
-        "REASONING_EFFORT": "medium"
+        "REASONING_EFFORT": "medium",
+        // Optional: API timeout in milliseconds (default: 60000)
+        "OPENAI_API_TIMEOUT": "60000",
+        // Optional: Maximum retry attempts (default: 3)
+        "OPENAI_MAX_RETRIES": "3"
       }
     }
   }
 }
 ```
+
+## Configuration
+
+### Environment Variables
+
+- **OPENAI_API_KEY** (required): Your OpenAI API key
+- **SEARCH_CONTEXT_SIZE** (optional): Controls the search context size
+  - Values: `low`, `medium`, `high`
+  - Default: `medium`
+- **REASONING_EFFORT** (optional): Controls the reasoning effort level
+  - Values: `low`, `medium`, `high`
+  - Default: `medium`
+- **OPENAI_API_TIMEOUT** (optional): API request timeout in milliseconds
+  - Default: `60000` (60 seconds)
+  - Example: `120000` for 2 minutes
+- **OPENAI_MAX_RETRIES** (optional): Maximum number of retry attempts for failed requests
+  - Default: `3`
+  - The SDK automatically retries on rate limits (429), server errors (5xx), and connection errors

--- a/index.ts
+++ b/index.ts
@@ -33,9 +33,6 @@ server.tool(
   { input: z.string().describe('Ask questions, search for information, or consult about complex problems in English.'), },
   async ({ input }) => {
     try {
-      // デバッグログ（オプション）
-      console.error(`[o3-search] Request started with timeout: ${config.timeout}ms, maxRetries: ${config.maxRetries}`);
-      
       const response = await openai.responses.create({
         model: 'o3',
         input,
@@ -55,25 +52,11 @@ server.tool(
       };
     } catch (error) {
       console.error("Error calling OpenAI API:", error);
-      
-      // エラーの種類に応じたメッセージ
-      let errorMessage = "An error occurred while processing your request.";
-      
-      if (error instanceof OpenAI.APIError) {
-        if (error.status === 429) {
-          errorMessage = "Rate limit exceeded. The request was retried but still failed. Please try again later.";
-        } else if (error.status && error.status >= 500) {
-          errorMessage = "OpenAI service is temporarily unavailable. Please try again later.";
-        }
-      } else if (error instanceof OpenAI.APIConnectionTimeoutError) {
-        errorMessage = "Request timed out. Please try again with a simpler query.";
-      }
-      
       return {
         content: [
           {
             type: "text",
-            text: `Error: ${errorMessage}`,
+            text: `Error: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
           },
         ],
       };


### PR DESCRIPTION
## Description

OpenAI API を使う時に、Tier が低いとスロットリングエラーがかかってしまうことがあるため、リトライを長めに取れるようなオプション値を追加してみました。  

When Tier rank is low, I usually encounter throttling error. So, I added configurable retry and timeout for OpenAI API via MCP environment values.
