### PR TITLE
Use background mode for requests to OpenAI

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -45,7 +45,7 @@ server.tool(
 
       while (response.status === "queued" || response.status === "in_progress") {
         console.log("Current status: " + response.status);
-        await new Promise(resolve => setTimeout(resolve, 2000)); // wait 2 seconds
+        await new Promise(resolve => setTimeout(resolve, 500)); // wait 0.5 seconds
         response = await openai.responses.retrieve(response.id);
       }
 


### PR DESCRIPTION
素晴らしいMCPサーバーをありがとうございます！
このMCPサーバーの使い始めに、何度かのタイムアウトエラー（Error: Request timed out.）に悩まされました。
OpenAIのResponse APIにはBackground modeがあり、これによってタイムアウトエラーを回避できるため、既存の実装をBackground modeに変更しました。
公式ドキュメント: https://platform.openai.com/docs/guides/background

Background modeは非同期的なタスクの実行とポーリングの簡易的なロジックで既存のロジックを置き換えることができます。
オプショナルなパラメータにすることも検討しましたが、UXに変更がなくデメリットも見当たらなかったため、デフォルトでBackground modeを使うように実装しています。

動作確認済みです。

<img width="1678" height="322" alt="スクリーンショット 2025-07-13 20 01 36" src="https://github.com/user-attachments/assets/df450161-82df-41a3-93ca-567297f03064" />

<img width="1691" height="1031" alt="スクリーンショット 2025-07-13 19 58 52" src="https://github.com/user-attachments/assets/3d046345-1f48-43d1-9bf1-bff6d94acf1b" />

---

Thank you for the great MCP server!
When I first started using this MCP server, I got a lot of error messages saying "Error: Request timed out."
OpenAI's Response API has a Background mode that can be used to avoid request timeout errors, so I changed the existing implementation to Background mode.
Here's a link to a guide on the OpenAI website: https://platform.openai.com/docs/guides/background.

Background mode can replace existing logic with asynchronous task execution and simple polling logic.
I thought about making it an optional parameter, but since there were no changes to the user experience and it didn't seem to have any problems, I implemented it to use background mode by default.

It has been confirmed to work.