### PR TITLE
Update README.md; changed syntax highlighting language from json to jsonc

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ claude mcp add o3 -s user \
 
 json:
 
-```json
+```jsonc
 {
   "mcpServers": {
     "o3-search": {
@@ -71,7 +71,7 @@ $ claude mcp add o3 -s user \
 
 json:
 
-```json
+```jsonc
 {
   "mcpServers": {
     "o3-search": {


### PR DESCRIPTION
## Summary

This is a minor change.

Currently, commented JSON formatted text is output as `json`, so comment lines are invalid.

<img width="600" height="440" alt="cap1" src="https://github.com/user-attachments/assets/4f09c195-8b40-4b96-aab0-6e853393f878" />

This can be resolved by setting the language used for syntax highlighting to `jsonc`.