### PR TITLE
fix: remove console.log breaking MCP JSON-RPC communication

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -84,7 +84,6 @@ server.tool(
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.log("MCP Server running on stdio");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
The console.log statement in main() was outputting to stdout, which interferes with the MCP protocol's JSON-RPC communication over stdio. This caused "Unexpected token 'M', "MCP Server"... is not valid JSON" errors when Claude tried to parse server responses.